### PR TITLE
add block to render_functions.js.twig so bundle

### DIFF
--- a/Resources/views/Datatable/render_functions.js.twig
+++ b/Resources/views/Datatable/render_functions.js.twig
@@ -6,6 +6,7 @@
  # For the full copyright and license information, please view the LICENSE
  # file that was distributed with this source code.
  #}
+ {% block renderFunctions %}
 var renderFunctionsAlreadyLoaded = true;
 
 function render_boolean(data, type, row, meta, trueIcon, falseIcon, trueLabel, falseLabel) {
@@ -143,3 +144,4 @@ function render_editable_boolean(data, type, row, meta, colData, trueLabel, fals
 
     return result;
 }
+{% endblock renderFunctions %}


### PR DESCRIPTION
I wanted to be able to add my own render functions to the existing ones. Bundle inheritance is the obvious way to do this. So in my `app/Resources` directory I added `SgDatatablesBundle/views/Datatable/render_functions.js.twig` and proceeded to try to extend `render_functions.js.twig`.

But because the original template contains no blocks, I could not extend it.  I've added an enclosing block to the template. Now, if you want to extend it, it's just a case of doing something like this:
````
{% extends 'SgDatatablesBundle:Datatable:render_functions.js.twig' %}

{% block renderFunctions %}
    parent();

    function render_list( data, type, row, meta ) {
        if (!data) return '';
    
        var ul = '<ul class="list-unstyled"><li>' + data.join('</li><li>') + '</li></ul>';
        return ul;
    };
    
{% endblock renderFunctions %}
````

I think it would be nice to wrap each render function in its own block so they could be individually over-ridden, but that's for another day.